### PR TITLE
Allow identifiers to start with an underscore

### DIFF
--- a/pakettic/parser.py
+++ b/pakettic/parser.py
@@ -18,7 +18,7 @@ vars().update(keywords)
 any_keyword = pp.MatchFirst(keywords.values()).setName("<keyword>")
 
 # Name
-Name = ~any_keyword + pp.Word(pp.alphas, pp.alphanums + "_")
+Name = ~any_keyword + pp.Word(pp.alphas + "_", pp.alphanums + "_")
 
 # LiteralString
 short_literal_string = (pp.QuotedString(


### PR DESCRIPTION
The following code fails to parse `function TIC() _a = 0 end` because the identifier `_a` begins with an underscore.
The  [Lua manual section 3.1](https://www.lua.org/manual/5.3/manual.html#3.1) states 

> Names (also called identifiers) in Lua can be any string of letters, digits, and underscores, not beginning with a digit and not being a reserved word.

This PR fixes this behavior.