### PR TITLE
Evaluate binary operators

### DIFF
--- a/pakettic/ast.py
+++ b/pakettic/ast.py
@@ -7,6 +7,7 @@ class Node:
     @property
     def precedence(self):
         return 0
+    original: "Node" = None
 
 
 @dataclass
@@ -239,6 +240,14 @@ class Numeral(Node):
         else:
             return f"0x{'%x' % self.whole}{'.' + '%x' % self.fractional if self.fractional != 0 else ''}{'p' + self.exponent if self.exponent != 0 else ''}" if self.hex \
                 else f"{self.whole}{'.' + str(self.fractional)[::-1] if self.fractional != 0 else ''}{'e' + str(self.exponent) if self.exponent != 0 else ''}"
+
+    @property
+    def value(self):
+        if self.fractional == 0 and self.exponent == 0:
+            return float(self.whole)
+        else:
+            r = repr(self)
+            return float.fromhex(r) if self.hex else float(r)
 
 
 @dataclass

--- a/pakettic/optimize.py
+++ b/pakettic/optimize.py
@@ -335,7 +335,7 @@ def visit(node: ast.Node, visitor: Callable[[ast.Node], None]):
     Visit each node of an abstract syntax tree recursively
         Parameters:
             node (ast.Node): A (root) node of the syntax tree to visit
-            visitor (Callable[[ast.Node], Node]): Callback function called for each node
+            visitor (Callable[[ast.Node], None]): Callback function called for each node
     """
     visitor(node)
 


### PR DESCRIPTION
This PR allows pakettic to evaluate binary operators where both operands are numbers, and where the result of the evaluation is an integer.

I've found this useful because I'm using the C preprocessor together with my TIC-80 code. This lets me use macros as a sort of "inline function".  If I use literal numbers as arguments to the macros, often times the inlined code has sub-expressions where all operands are numbers, and the whole thing become smaller if we evaluate those sub-expressions at packing time.