### PR TITLE
feat: convert numbers between hex and decimal

### DIFF
--- a/pakettic/optimize.py
+++ b/pakettic/optimize.py
@@ -197,6 +197,10 @@ def mutate(root: ast.Node, rand: random.Random) -> ast.Node:
             def _mutation2():
                 node.no_hex = not node.no_hex
             mutations.append(_mutation2)
+        elif type(node) == ast.Numeral:
+            def _mutation():
+                node.hex = not node.hex
+            mutations.append(_mutation)
 
         if node.original != None and parent != None:
             def _mutation():

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -54,3 +54,15 @@ class TestOptimization(unittest.TestCase):
                     self.assertGreater(len(printed), 0)
                 except Exception as err:
                     self.fail(err)
+
+    def test_minify(self):
+        cases = {
+                'poke(0x3fc0,0)': 'poke(16320,0)',
+                'print(1000000000001)': 'print(0xe8d4a51001)',
+        }
+        for a, expected in cases.items():
+            with self.subTest(parsed=a):
+                root = parser.parse_string(a)
+                opt_root = optimize.dlas(root, steps=100, list_length=5, init_margin=0, seed=0, cost_func=lambda root,_: len(printer.format(root)))
+                printed = printer.format(opt_root)
+                self.assertEqual(printed, expected)


### PR DESCRIPTION
I noticed a `0x3fc0` didn't get converted to the shorter `16320`. Here's a unit test and implementation for converting in both directions (though dec->hex is rarely useful).